### PR TITLE
sha256方法使用后端实现

### DIFF
--- a/templates/cloud115_library.html
+++ b/templates/cloud115_library.html
@@ -996,11 +996,24 @@
                 .replace(/\//g, '_')
                 .replace(/=+$/, '');
         }
+
+        async function sha256_base64(text){
+            const response = await fetch(`/tools/sha256/${text}`);
+            const data = await response.json();
+            console.log(data)
+            if (data.success && data.result && data.result.length > 0) {
+                return data.result
+            }else {
+                return ""
+            }
+        }
         
         // Generate PKCE parameters
         async function generatePKCEParams() {
             codeVerifier = generateRandomString(64);
-            const codeChallenge = base64URLEncode(await sha256(codeVerifier));
+            //此方法中的window.crypto.subtle.digest仅可在https或localhost中使用，使用后端代替
+            // const codeChallenge = base64URLEncode(await sha256(codeVerifier));
+            const codeChallenge = await sha256_base64(codeVerifier);
             return {
                 codeVerifier: codeVerifier,
                 codeChallenge: codeChallenge,

--- a/webserver.py
+++ b/webserver.py
@@ -6095,6 +6095,41 @@ def jellyfin_playback_info():
         logging.error(error_message)
         return jsonify({"status": "error", "message": error_message}), 500
 
+
+@app.route('/tools/sha256/<text>', methods=['GET'])
+def sha256_base_encoding(text):
+    """sha256加密及base64Encode
+
+    Args:
+        text: 待加密的字符串 (text)
+
+    Returns:
+        JSON: 包含加密完成的JSON响应
+    """
+    try:
+        encrypted = hashlib.sha256(text.encode('utf-8')).digest()
+        result = base64.urlsafe_b64encode(encrypted).rstrip(b'=').decode('ascii')
+        # 构造响应
+        if result and len(result) > 0:
+            return jsonify({
+                "success": True,
+                "result": result
+            })
+        else:
+            return jsonify({
+                "success": False,
+                "message": f"undone encrypt {text}",
+                "result": ""
+            })
+    except Exception as e:
+        app.logger.error(f"error encrypt: {e}")
+        return jsonify({
+            "success": False,
+            "message": str(e),
+            "result": ""
+        })
+
+
 # Start the server
 if __name__ == '__main__':
     # Initialize libraries only once when the app starts


### PR DESCRIPTION
原window.crypto.subtle.digest仅可在https或localhost中使用，而直接在局域网的其他机器部署时是http访问的，此时会获取不到115的二维码。将sha256方法使用后端代替即可。
<img width="1707" height="634" alt="图片" src="https://github.com/user-attachments/assets/24718cd2-4d82-4282-81c8-947707d6bc9b" />

